### PR TITLE
add "Serializable" interface to PositionList

### DIFF
--- a/mmstudio/src/org/micromanager/api/PositionList.java
+++ b/mmstudio/src/org/micromanager/api/PositionList.java
@@ -45,7 +45,7 @@ import org.micromanager.utils.MMSerializationException;
  * Navigation list of positions for the XYStage.
  * Used for multi site acquisition support.
  */
-public class PositionList {
+public class PositionList implements Serializable {
    private ArrayList<MultiStagePosition> positions_;
    private final static String ID = "Micro-Manager XY-position list";
    private final static String ID_KEY = "ID";


### PR DESCRIPTION
Add `Serializable` interface to `PositionList` to allow transfer via Java RMI.
My local workaround extends the PositionList with a serializable subclass and works fine, so I don't expect any problems.

Keeping the warning about `serialVersionUID` deliberately, as the maintainers of micro-manager probably have a better strategy for this.